### PR TITLE
Remove process reference in the lib inducing unable to load the lib.

### DIFF
--- a/packages/hw-transport-usb/src/decorators.ts
+++ b/packages/hw-transport-usb/src/decorators.ts
@@ -1,15 +1,9 @@
-
-const isDev = process.env.KEYSTONE_USB_ENV === 'development';
-
 export function logMethod(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<any>) {
   const originalMethod = descriptor.value;
 
   descriptor.value = async function (...args: any[]) {
     const params = args.map(a => JSON.stringify(a)).join();
     const result = await originalMethod.apply(this, args);
-    if (isDev) {
-      console.log(`[${new Date().toISOString()}] Call: ${propertyName}(${params}) => ${JSON.stringify(result)}`);
-    }
     return result;
   };
 


### PR DESCRIPTION
When using the library for WebUSB, the process object is not valid, as it does not exist in the web environment.

This requires adding something like the following in the browser to enable the library to work:

```js
window.process = {
  env: {
    KEYSTONE_USB_ENV: "development",
  },
};
```